### PR TITLE
Remove `non-nullable` experiment from analysis_options

### DIFF
--- a/built_value/analysis_options.yaml
+++ b/built_value/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  enable-experiment:
-    - non-nullable

--- a/end_to_end_test/analysis_options.yaml
+++ b/end_to_end_test/analysis_options.yaml
@@ -1,9 +1,6 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
-  enable-experiment:
-    - non-nullable
-
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false


### PR DESCRIPTION
No longer needed!
